### PR TITLE
Make pyts.io.read usable in python3

### DIFF
--- a/pyts/base.py
+++ b/pyts/base.py
@@ -13,6 +13,7 @@ This module:
  d) Defines several abstract base classes.
 
 """
+from __future__ import division, print_function
 from . import pyts_numpy as np
 from numpy import float32, complex64
 from .misc import lowPrimeFact_near
@@ -20,11 +21,11 @@ from os import path
 try:
     from .tslib import tslib  # The file tslib.so contains the module 'tslib'.
 except ImportError:
-    print """
+    print("""
     ***Warning***: 'tslib' did not load correctly.  pyTurbSim
     will produce accurate results, but MUCH less efficiently.
     Consider compiling the tslib to improve performance.
-    """
+    """)
     tslib = None
 
 dbg = None
@@ -357,7 +358,7 @@ class gridObj(tsBaseObj):
 
     @property
     def n_f(self,):
-        return self.n_t / 2
+        return self.n_t // 2
 
     @property
     def df(self,):
@@ -369,7 +370,7 @@ class gridObj(tsBaseObj):
 
     @property
     def ihub(self,):
-        return (self.n_z / 2, self.n_y / 2)
+        return (self.n_z // 2, self.n_y // 2)
 
     @property
     def shape(self,):

--- a/pyts/io/read.py
+++ b/pyts/io/read.py
@@ -94,31 +94,31 @@ def turbsim(fname):
     fname = checkname(fname, ['.bts'])
     u_scl = np.zeros(3, np.float32)
     u_off = np.zeros(3, np.float32)
-    fl = file(fname, 'rb')
-    (junk,
-     n_z,
-     n_y,
-     n_tower,
-     n_t,
-     dz,
-     dy,
-     dt,
-     uhub,
-     zhub,
-     z0,
-     u_scl[0],
-     u_off[0],
-     u_scl[1],
-     u_off[1],
-     u_scl[2],
-     u_off[2],
-     strlen) = unpack(e + 'h4l12fl', fl.read(70))
-    center = z0 + (n_z - 1) * dz / 2.0
-    #print fname, u_scl, u_off
-    desc_str = fl.read(strlen)  # skip these bytes.
-    nbt = 3 * n_y * n_z * n_t
-    dat = np.rollaxis(np.fromstring(fl.read(2 * nbt), dtype=np.int16).astype(
-        np.float32).reshape([3, n_y, n_z, n_t], order='F'), 2, 1)
+    with open(fname, 'rb') as fl:
+        (junk,
+         n_z,
+         n_y,
+         n_tower,
+         n_t,
+         dz,
+         dy,
+         dt,
+         uhub,
+         zhub,
+         z0,
+         u_scl[0],
+         u_off[0],
+         u_scl[1],
+         u_off[1],
+         u_scl[2],
+         u_off[2],
+         strlen) = unpack(e + 'h4l12fl', fl.read(70))
+        center = z0 + (n_z - 1) * dz / 2.0
+        #print fname, u_scl, u_off
+        desc_str = fl.read(strlen)  # skip these bytes.
+        nbt = 3 * n_y * n_z * n_t
+        dat = np.rollaxis(np.fromstring(fl.read(2 * nbt), dtype=np.int16).astype(
+            np.float32).reshape([3, n_y, n_z, n_t], order='F'), 2, 1)
     dat -= u_off[:, None, None, None]
     dat /= u_scl[:, None, None, None]
     # Create the tsdata object.

--- a/pyts/main.py
+++ b/pyts/main.py
@@ -14,7 +14,7 @@ from .specModels.base import specModelBase, specObj
 from .cohereModels.base import cohereModelBase, cohereObj, cohereUser
 from .stressModels.base import stressModelBase, stressObj
 from .phaseModels.api import randPhase
-import _version as ver
+from ._version import *
 from .io import write
 from numpy import random
 from numpy import ulonglong
@@ -423,7 +423,7 @@ class tsrun(object):
         Model names and initialization parameters.
         """
         out = dict()
-        out['version'] = (ver.__prog_name__, ver.__version__, ver.__version_date__)
+        out['version'] = (__prog_name__, __version__, __version_date__)
         out['RandSeed'] = self.RandSeed
         out['StartTime'] = self._starttime
         if hasattr(self, '_config'):

--- a/pyts/phaseModels/api.py
+++ b/pyts/phaseModels/api.py
@@ -7,4 +7,4 @@ randPhase
   A uniform-distribution random-phase model.
 
 """
-from main import randPhase
+from .main import randPhase

--- a/pyts/stressModels/base.py
+++ b/pyts/stressModels/base.py
@@ -6,6 +6,7 @@ stress
 
 """
 
+from __future__ import print_function
 from .. import base
 np = base.np
 
@@ -152,8 +153,8 @@ class stressObj(base.calcObj, base.gridProps):
         # stresses.  In the future it may make sense to adjust/modify the
         # stresses to make them valid?
         if ~(self.validity.all()):
-            print self.validity.shape
-            print self.validity
+            print(self.validity.shape)
+            print(self.validity)
             raise Exception('The input reynolds stresses are inconsistent.')
 
     def calc_phases(self, phases):


### PR DESCRIPTION
We would like to use the `pyts.io.read` module from python3. This patch fixes some syntax errors and some semantic errors, but might not be complete.