### PR TITLE
Fixed integer range for turbsim binary output

### DIFF
--- a/pyts/io/write.py
+++ b/pyts/io/write.py
@@ -154,7 +154,7 @@ def turbsim(fname, tsdat):
     """
     ts = tsdat.utotal
     intmin = -32768
-    intrng = 65536
+    intrng = 65535
     u_minmax = np.empty((3, 2), dtype=np.float32)
     u_off = np.empty((3), dtype=np.float32)
     u_scl = np.empty((3), dtype=np.float32)


### PR DESCRIPTION
The integer range needs to be 65535 otherwise the scaling will be slightly off. 
(see for instance https://github.com/OpenFAST/openfast/blob/f2419c5d1c23caad9146b95a103d89e9dcaefe30/modules/turbsim/src/TS_FileIO.f90#L2202)